### PR TITLE
Add: collection page API Router 생성 및 엔드포인트 (/collection) 추가

### DIFF
--- a/controllers/product.js
+++ b/controllers/product.js
@@ -1,4 +1,8 @@
-const { readTop20, readProductDetails } = require('../models/product');
+const {
+  readTop20,
+  readProductDetails,
+  readCollectionListByCategory,
+} = require('../models/product');
 
 const readTop20Controller = async (req, res) => {
   try {
@@ -21,7 +25,19 @@ const readProductDetailsController = async (req, res) => {
   }
 };
 
+const readCollectionListByCategoryController = async (req, res) => {
+  try {
+    const { id } = req.query;
+    const collectionList = await readCollectionListByCategory(id);
+    console.log(collectionList);
+    return res.status(200).json({ data: collectionList });
+  } catch (err) {
+    res.status(err.statusCode || 500).json({ message: err.message });
+  }
+};
+
 module.exports = {
   readTop20Controller,
   readProductDetailsController,
+  readCollectionListByCategoryController,
 };

--- a/models/product.js
+++ b/models/product.js
@@ -65,7 +65,47 @@ async function readProductDetails(id) {
   return productDetails;
 }
 
+async function readCollectionListByCategory(id) {
+  const collectionListByCategory = await prisma.$queryRawUnsafe(`
+  SELECT
+      p.id AS productId,
+      p.name AS productName,
+      p.price,
+      cg.id AS categoryId,
+      pa.colorImage,
+      piJA.stockBySize
+  FROM (
+      SELECT pc.product_id, JSON_ARRAYAGG(JSON_OBJECT("id", pc.id, "color", JSON_OBJECT("id", pc.color_id, "color", c.color), "images", pi.images)) AS colorImage
+      FROM product_color pc
+      JOIN color c on pc.color_id = c.id
+      JOIN (
+          SELECT product_color_id AS id, JSON_ARRAYAGG(JSON_OBJECT("id",product_images.id, "url", product_images.url)) AS images
+          FROM product_images WHERE MOD(id,2) = 1
+          GROUP BY product_color_id
+          ) pi on pi.id = pc.id
+      GROUP BY pc.product_id
+      ) pa
+  JOIN products p ON p.id = pa.product_id
+  JOIN category cg ON cg.id = p.category_id
+  JOIN product_color pc2 on p.id = pc2.product_id
+  JOIN color cc ON pc2.color_id = cc.id
+  JOIN product_details pd ON pd.product_color_id = pc2.id
+  JOIN (SELECT pcc.product_id, JSON_ARRAYAGG(JSON_OBJECT("id", pcc.id, "color", JSON_OBJECT("id", pcc.color_id, "color", ccc.color),"size_stock", ss.size_stock)) AS stockBySize
+      FROM product_color pcc
+      JOIN (SELECT product_color_id, JSON_ARRAYAGG(JSON_OBJECT("size", s.size, "stock", product_details.stock)) AS size_stock
+          FROM product_details
+          JOIN size s on product_details.size_id = s.id
+          GROUP BY product_details.product_color_id) ss ON ss.product_color_id = pcc.id
+      JOIN color ccc on ccc.id = pcc.color_id
+      GROUP BY pcc.product_id) piJA on piJA.product_id = p.id
+  GROUP BY pa.product_id
+  ${id ? `HAVING categoryId = ${id}` : ``}
+  `);
+  return collectionListByCategory;
+}
+
 module.exports = {
   readTop20,
   readProductDetails,
+  readCollectionListByCategory,
 };

--- a/routes/product.js
+++ b/routes/product.js
@@ -1,6 +1,7 @@
 const {
   readTop20Controller,
   readProductDetailsController,
+  readCollectionListByCategoryController,
 } = require('../controllers/product');
 const express = require('express');
 
@@ -8,5 +9,6 @@ const routes = express.Router();
 
 routes.get('/top20', readTop20Controller);
 routes.get('/product/:id', readProductDetailsController);
+routes.get('/collection', readCollectionListByCategoryController);
 
 module.exports = routes;


### PR DESCRIPTION


## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 컬렉션 리스트를 위한 엔드포인트 구현
- 카테고리별 상품 리스트와 전체 상품 리스트를 불러오는 API

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- controllers, models 디렉토리에 collection page 관련 부분 코드 추가
- models에서 readCollectionListByCategory 함수에 해당 쿼리문 추가
        - queryRawUnsafe로 삼항연산자(템플릿 리터럴) 넣어서, 카테고리 아이디가 들어갔을 때에는 id별 상품 리스트를 불러오고, id가 없는경우 all 상품 리스트를 불러올 수 있도록  구현
- controllers에서 readCollectionListByCategoryController 코드 추가

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- queryRawUnsafe는 템플릿 리터럴을 쿼리문 내에서 사용하는 경우 사용하는 메서드입니다.
- 템플릿 리터럴 안에서 삼항연산이 사용가능하다는 것을 알게 되었습니다. 

<br />

## :: 기타 질문 및 특이 사항

- 쿼리 스트링을 이용하여 id가 있고 없을 때까지 하나의 API로 구현.